### PR TITLE
pypi.python.org URL needs to be https

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -37,5 +37,5 @@ python_setuptools_tgz_local_path: "{{python_sandbox_path}}/{{python_setuptools_t
 
 # pip tarball paths
 python_pip_tgz_file_name: pip-{{python_pip_version}}.tar.gz
-python_pip_tgz_url: http://pypi.python.org/packages/source/p/pip/{{python_pip_tgz_file_name}}
+python_pip_tgz_url: https://pypi.python.org/packages/source/p/pip/{{python_pip_tgz_file_name}}
 python_pip_tgz_local_path: "{{python_sandbox_path}}/{{python_pip_tgz_file_name}}"


### PR DESCRIPTION
The template for `python_pip_tgz_url` needs to changed from `http` to `https`

Also this has not been updated at [Ansible Galaxy](https://galaxy.ansible.com/whiskerlabs/python), where the latest version is [v0.0.3](https://github.com/whiskerlabs/ansible-python/tree/v0.0.3), which itself is behind the current master branch.